### PR TITLE
Add link to message that put the user into reformation

### DIFF
--- a/cogs/moderation/reformation.py
+++ b/cogs/moderation/reformation.py
@@ -161,10 +161,12 @@ class Reformation(commands.Cog):
 
             await case_channel.send(embed=welcome_embed)
 
+            message = await interaction.original_message()
+
             embed = SersiEmbed(
                 title="User Has Been Sent to Reformation",
                 description=f"Moderator {interaction.user.mention} ({interaction.user.id}) has sent user {member.mention}"
-                f" ({member.id}) to reformation.\n\n" + f"**__Reason:__**\n{reason}",
+                f" ({member.id}) to reformation.\n\n" + f"**__Reason:__**\n{reason}\n\n[Link to context]({message.jump_url})",
                 color=nextcord.Color.from_rgb(237, 91, 6),
             )
 


### PR DESCRIPTION
This should make it a bit easier to go back and scroll through the messages of someone once put into reformation.

For the record, this code is largely untested, since I don't have the setup needed for that.