### PR TITLE
5.0.1 release

### DIFF
--- a/cogs/community/voice.py
+++ b/cogs/community/voice.py
@@ -1,26 +1,23 @@
 import nextcord
-import requests
 from nextcord.ext import commands
 
-import discordTokens
 from utils.config import Configuration
 from utils.perms import permcheck, is_staff
 from utils.sersi_embed import SersiEmbed
 
 
 class Voice(commands.Cog):
-    def __init__(self, bot, config: Configuration):
+    def __init__(self, bot: commands.Bot, config: Configuration):
         self.bot = bot
         self.config = config
         self.sersisuccess = self.config.emotes.success
         self.sersifail = self.config.emotes.fail
-        self.unlocked_channels = []
-    
+
     @nextcord.slash_command(
-            dm_permission=False,
-            guild_ids=[1166770860787515422, 977377117895536640, 856262303795380224],
-            description="Mass move members from one VC to another."
-        )
+        dm_permission=False,
+        guild_ids=[1166770860787515422, 977377117895536640, 856262303795380224],
+        description="Mass move members from one VC to another.",
+    )
     async def mass_move(
         self,
         interaction: nextcord.Interaction,
@@ -31,7 +28,7 @@ class Voice(commands.Cog):
             return
 
         await interaction.response.defer(ephemeral=True)
-        
+
         memberlist = ""
         for member in current.members:
             memberlist = memberlist + f"**{member.display_name}** ({member.id})\n"
@@ -50,13 +47,16 @@ class Voice(commands.Cog):
         embed = SersiEmbed(
             title="Members mass moved to other VC",
             description="All members in channel were moved to another VC",
-            fields=[{
-                "Move done by:": interaction.user.mention,
-                "From channel:": current.mention,
-                "To channel:": target.mention,
-            }, {
-                "Members Moved:": memberlist,
-            }],
+            fields=[
+                {
+                    "Move done by:": interaction.user.mention,
+                    "From channel:": current.mention,
+                    "To channel:": target.mention,
+                },
+                {
+                    "Members Moved:": memberlist,
+                },
+            ],
             footer="Voice Cog",
             footer_icon=interaction.user.avatar.url,
         )
@@ -64,64 +64,36 @@ class Voice(commands.Cog):
         channel = interaction.guild.get_channel(self.config.channels.logging)
         await channel.send(embed=embed)
 
-
     @commands.Cog.listener()
-    async def on_voice_state_update(self, member, before, after):
-        def make_embed(message: str) -> dict:
-            return {"color": 0xED5B06, "description": message}
-
-        if (
-            after.channel != before.channel
-        ):  # channel change. at least one message has to be sent
+    async def on_voice_state_update(
+        self,
+        member: nextcord.Member,
+        before: nextcord.VoiceState,
+        after: nextcord.VoiceState,
+    ):
+        if after.channel != before.channel:
+            # channel change. at least one message has to be sent
             # specifications regardless of message content
-            headers = {
-                "Authorization": f"Bot {discordTokens.getToken()}",
-                "Content-Type": "application/json; charset=UTF-8",
-            }
 
             if after.channel is not None:
-                url = (
-                    f"https://discord.com/api/v10/channels/{after.channel.id}/messages"
+                embed = SersiEmbed(
+                    description=f"Hello {member.mention}, welcome to {after.channel.mention}!"
+                    if before.channel is None
+                    else f"Hello {member.mention}, welcome to {after.channel.mention}! Glad you came over from {before.channel.mention}",
+                    footer=member.display_name,
+                    footer_icon=member.avatar.url,
                 )
-                if before.channel is not None:
-                    json = {
-                        "embeds": [
-                            make_embed(
-                                f"Hello {member.mention}, welcome to {after.channel.mention}! Glad you came over from {before.channel.mention}"
-                            )
-                        ]
-                    }
-                else:
-                    json = {
-                        "embeds": [
-                            make_embed(
-                                f"Hello {member.mention}, welcome to {after.channel.mention}!"
-                            )
-                        ]
-                    }
-                requests.post(url, headers=headers, json=json)
+                await after.channel.send(embed=embed)
 
             if before.channel is not None:
-                url = (
-                    f"https://discord.com/api/v10/channels/{before.channel.id}/messages"
+                embed = SersiEmbed(
+                    description=f"{member.mention} has left the voice channel. Goodbye!"
+                    if after.channel is None
+                    else f"{member.mention} ran off to {after.channel.mention}, guess the grass was greener there!",
+                    footer=member.display_name,
+                    footer_icon=member.avatar.url,
                 )
-                if after.channel is not None:
-                    json = {
-                        "embeds": [
-                            make_embed(
-                                f"{member.mention} ran off to {after.channel.mention}, guess the grass was greener there!"
-                            )
-                        ]
-                    }
-                else:
-                    json = {
-                        "embeds": [
-                            make_embed(
-                                f"{member.mention} has left the voice channel. Goodbye!"
-                            )
-                        ]
-                    }
-                requests.post(url, headers=headers, json=json)
+                await before.channel.send(embed=embed)
 
 
 def setup(bot: commands.Bot, **kwargs):

--- a/cogs/misc/config.py
+++ b/cogs/misc/config.py
@@ -4,7 +4,13 @@ from nextcord.ext import commands
 
 from utils.sersi_embed import SersiEmbed
 from utils.config import Configuration, Configurator
-from utils.perms import permcheck, is_sersi_contributor, is_staff, is_dark_mod, is_cet_lead
+from utils.perms import (
+    permcheck,
+    is_sersi_contributor,
+    is_staff,
+    is_dark_mod,
+    is_cet_lead,
+)
 
 
 class Config(commands.Cog):
@@ -182,7 +188,7 @@ class Config(commands.Cog):
     async def set_channel_setting(
         self, interaction: nextcord.Interaction, setting: str
     ):
-        if not await permcheck(interaction, is_dark_mod):
+        if not is_dark_mod(interaction.user):
             return
 
         await interaction.response.send_autocomplete(
@@ -247,7 +253,7 @@ class Config(commands.Cog):
 
     @remove_channel.on_autocomplete("channel")
     async def remove_channel_id(self, interaction: nextcord.Interaction, channel: str):
-        if not await permcheck(interaction, is_dark_mod):
+        if not is_dark_mod(interaction.user):
             return
 
         await interaction.response.send_autocomplete(
@@ -312,7 +318,7 @@ class Config(commands.Cog):
     async def remove_category_name(
         self, interaction: nextcord.Interaction, category: str
     ):
-        if not await permcheck(interaction, is_dark_mod):
+        if not is_dark_mod(interaction.user):
             return
 
         await interaction.response.send_autocomplete(
@@ -343,7 +349,7 @@ class Config(commands.Cog):
 
     @set_role.on_autocomplete("setting")
     async def set_role_setting(self, interaction: nextcord.Interaction, setting):
-        if not await permcheck(interaction, is_dark_mod):
+        if not is_dark_mod(interaction.user):
             return
 
         await interaction.response.send_autocomplete(
@@ -376,7 +382,7 @@ class Config(commands.Cog):
     async def set_permission_role_setting(
         self, interaction: nextcord.Interaction, setting: str
     ):
-        if not await permcheck(interaction, is_dark_mod):
+        if not is_dark_mod(interaction.user):
             return
 
         await interaction.response.send_autocomplete(
@@ -443,7 +449,7 @@ class Config(commands.Cog):
     async def remove_punishment_role_name(
         self, interaction: nextcord.Interaction, role: str
     ):
-        if not await permcheck(interaction, is_dark_mod):
+        if not is_dark_mod(interaction.user):
             return
 
         await interaction.response.send_autocomplete(
@@ -510,7 +516,7 @@ class Config(commands.Cog):
     async def remove_opt_in_role_name(
         self, interaction: nextcord.Interaction, role: str
     ):
-        if not await permcheck(interaction, is_cet_lead):
+        if not is_cet_lead(interaction.user):
             return
 
         await interaction.response.send_autocomplete(

--- a/cogs/misc/config.py
+++ b/cogs/misc/config.py
@@ -526,7 +526,7 @@ class Config(commands.Cog):
 
         self.config.load()
 
-        await interaction.followup.send(
+        await interaction.response.send_message(
             f"{self.config.emotes.success} Config reloaded."
         )
 

--- a/cogs/misc/errorhandling.py
+++ b/cogs/misc/errorhandling.py
@@ -1,11 +1,31 @@
+import traceback
+from enum import Enum
+
 import nextcord
 from nextcord.ext import commands
-from nextcord import InteractionType
-
 
 from utils.config import Configuration
 from utils.sersi_embed import SersiEmbed
 from utils.sersi_exceptions import CommandDisabledException
+
+
+class ApplicationCommandType(Enum):
+    SLASH_COMMAND = 1
+    USER = 2
+    MESSAGE = 3
+
+
+class ApplicationCommandOptionType(Enum):
+    SUB_COMMAND = 1
+    SUB_COMMAND_GROUP = 2
+    STRING = 3
+    INTEGER = 4
+    BOOLEAN = 5
+    USER = 6
+    CHANNEL = 7
+    ROLE = 8
+    MENTIONABLE = 9
+    FLOAT = 10
 
 
 class ErrorHandling(commands.Cog):
@@ -14,6 +34,67 @@ class ErrorHandling(commands.Cog):
         self.config = config
         if bot.is_ready():
             self.error_guild = bot.get_guild(config.guilds.errors)
+
+    async def process_options(
+        self, options: list[dict], interaction: nextcord.Interaction
+    ) -> tuple[str, dict[str, str]]:
+        fields = {}
+        subcommand = ""
+        for option in options:
+            match ApplicationCommandOptionType(option["type"]):
+                case (
+                    ApplicationCommandOptionType.SUB_COMMAND
+                    | ApplicationCommandOptionType.SUB_COMMAND_GROUP
+                ):
+                    subcommand, fields = await self.process_options(
+                        option["options"], interaction
+                    )
+                    subcommand = (
+                        f"{option['name']} {subcommand}"
+                        if subcommand
+                        else option["name"]
+                    )
+                case (
+                    ApplicationCommandOptionType.STRING
+                    | ApplicationCommandOptionType.INTEGER
+                    | ApplicationCommandOptionType.FLOAT
+                ):
+                    fields[option["name"]] = option["value"]
+                case ApplicationCommandOptionType.BOOLEAN:
+                    if option["value"]:
+                        fields[option["name"]] = self.config.emotes.success
+                    else:
+                        fields[option["name"]] = self.config.emotes.fail
+                case (
+                    ApplicationCommandOptionType.USER
+                    | ApplicationCommandOptionType.CHANNEL
+                    | ApplicationCommandOptionType.ROLE
+                    | ApplicationCommandOptionType.MENTIONABLE
+                ):
+                    target = (
+                        interaction.guild.get_member(int(option["value"]))
+                        or interaction.guild.get_channel(int(option["value"]))
+                        or interaction.guild.get_role(int(option["value"]))
+                    )
+
+                    if target is None:
+                        try:
+                            target = await self.bot.fetch_user(int(option["value"]))
+                        except nextcord.NotFound:
+                            fields[option["name"]] = f"`{option['value']}`"
+
+                    if isinstance(target, nextcord.Role):
+                        fields[option["name"]] = f"{target.name} (`{target.id}`)"
+                    elif isinstance(target, nextcord.TextChannel):
+                        fields[
+                            option["name"]
+                        ] = f"{target.mention} (#{target.name} `{target.id}`)"
+                    elif target is not None:
+                        fields[
+                            option["name"]
+                        ] = f"{target.mention} ({target.display_name} `{target.id}`)"
+
+        return subcommand, fields
 
     @commands.Cog.listener()
     async def on_application_command_error(
@@ -28,71 +109,74 @@ class ErrorHandling(commands.Cog):
         channel = self.error_guild.get_channel(self.config.channels.errors)
         if channel is None:
             return
-        else:
-            if interaction.type == InteractionType.application_command:
-                await channel.send(
-                    embed=SersiEmbed(
-                        title="An Error Has Occurred",
-                        description=str(interaction.data),
-                        fields={
-                            "Server:": f"{interaction.guild.name} ({interaction.guild.id})",
-                            "Channel:": f"{interaction.channel.name} ({interaction.channel.id})",
-                            "Error:": error,
-                            "URL:": interaction.channel.jump_url,
-                        },
-                        colour=nextcord.Color.from_rgb(208, 29, 29),
-                    )
+
+        embed_fields = {
+            "Context:": f"{interaction.channel.mention} (#{interaction.channel.name} `{interaction.channel.id}`)",
+            "User:": f"{interaction.user.mention} ({interaction.user.display_name} `{interaction.user.id}`)",
+        }
+
+        match ApplicationCommandType(interaction.data.get("type")):
+            case ApplicationCommandType.SLASH_COMMAND:
+                subcommand, fields = await self.process_options(
+                    interaction.data.get("options", []), interaction
                 )
-                try:
-                    await interaction.response.send_message(
-                        "An error has occurred. An alert has been sent to my creators.",
-                        ephemeral=True,
-                    )
-
-                except [
-                    nextcord.HTTPException,
-                    nextcord.NotFound,
-                    nextcord.InteractionResponded,
-                ]:
-                    await interaction.followup.send(
-                        "An error has occurred. An alert has been sent to my creators.",
-                        ephemeral=True,
-                    )
-                return
-            else:
-                await channel.send(
-                    embed=SersiEmbed(
-                        title="An Error Has Occurred",
-                        fields={
-                            "Server:": f"{interaction.guild.name} ({interaction.guild.id})",
-                            "Channel:": f"{interaction.channel.name} ({interaction.channel.id})",
-                            "Command:": str(interaction.type),
-                            "Error:": error,
-                            "URL:": interaction.channel.jump_url,
-                        },
-                        colour=nextcord.Color.from_rgb(208, 29, 29),
-                    )
+                embed_fields["Command:"] = (
+                    f"```/{interaction.data.get('name')} {subcommand}```"
+                    if subcommand
+                    else f"```/{interaction.data.get('name')}```"
                 )
+                embed_fields.update(fields)
+            case ApplicationCommandType.USER:
+                target = interaction.guild.get_member(
+                    int(interaction.data.get("target_id"))
+                )
+                embed_fields["Command:"] = f"{interaction.data.get('name')}"
+                if target is not None:
+                    embed_fields[
+                        "Target:"
+                    ] = f"{target.mention} ({target.display_name} `{target.id}`)"
+                else:
+                    embed_fields["Target:"] = f"`{interaction.data.get('target_id')}`"
+            case ApplicationCommandType.MESSAGE:
+                embed_fields["Command:"] = f"{interaction.data.get('name')}"
 
-                try:
-                    await interaction.response.send_message(
-                        "An error has occurred. An alert has been sent to my creators.",
-                        ephemeral=True,
+                if message := await interaction.channel.fetch_message(
+                    int(interaction.data.get("target_id"))
+                ):
+                    embed_fields.update(
+                        {
+                            "Message Author:": f"{message.author.mention} ({message.author.display_name} `{message.author.id}`)",
+                            "Message Content:": message.content,
+                            "Message URL:": f"{message.jump_url}",
+                            "Message Sent:": f"<t:{int(message.created_at.timestamp())}:F>",
+                        }
                     )
+                else:
+                    embed_fields[
+                        "Message:"
+                    ] = f"{interaction.channel.jump_url}/{interaction.data.get('target_id')}"
 
-                except [
-                    nextcord.HTTPException,
-                    nextcord.NotFound,
-                    nextcord.InteractionResponded,
-                ]:
-                    await interaction.followup.send(
-                        "An error has occurred. An alert has been sent to my creators.",
-                        ephemeral=True,
+        await channel.send(
+            embed=SersiEmbed(
+                title="An Error Has Occurred",
+                description="".join(
+                    traceback.format_exception(
+                        type(error), value=error, tb=error.__traceback__
                     )
-                return
+                )[:4096],
+                fields=embed_fields,
+                footer=f"{interaction.guild.name} ({interaction.guild.id})",
+                footer_icon=interaction.guild.icon.url,
+                colour=nextcord.Color.from_rgb(208, 29, 29),
+            )
+        )
+        await interaction.send(
+            "An error has occurred. An alert has been sent to my creators.",
+            ephemeral=True,
+        )
 
     @commands.Cog.listener()
-    async def on_command_error(self, ctx, error):
+    async def on_command_error(self, ctx: commands.Context, error: Exception):
         if isinstance(error, commands.CommandNotFound):
             await ctx.send(f"{self.config.emotes.fail} That command does not exist.")
             return

--- a/cogs/misc/errorhandling.py
+++ b/cogs/misc/errorhandling.py
@@ -81,7 +81,7 @@ class ErrorHandling(commands.Cog):
                         try:
                             target = await self.bot.fetch_user(int(option["value"]))
                         except nextcord.NotFound:
-                            fields[option["name"]] = f"`{option['value']}`"
+                            pass
 
                     if isinstance(target, nextcord.Role):
                         fields[option["name"]] = f"{target.name} (`{target.id}`)"
@@ -93,6 +93,8 @@ class ErrorHandling(commands.Cog):
                         fields[
                             option["name"]
                         ] = f"{target.mention} ({target.display_name} `{target.id}`)"
+                    else:
+                        fields[option["name"]] = f"`{option['value']}`"
 
         return subcommand, fields
 

--- a/cogs/misc/errorhandling.py
+++ b/cogs/misc/errorhandling.py
@@ -4,6 +4,7 @@ from enum import Enum
 import nextcord
 from nextcord.ext import commands
 
+from utils.base import limit_string
 from utils.config import Configuration
 from utils.sersi_embed import SersiEmbed
 from utils.sersi_exceptions import CommandDisabledException
@@ -161,11 +162,11 @@ class ErrorHandling(commands.Cog):
         await channel.send(
             embed=SersiEmbed(
                 title="An Error Has Occurred",
-                description="".join(
+                description=f"""```{limit_string("".join(
                     traceback.format_exception(
                         type(error), value=error, tb=error.__traceback__
                     )
-                )[:4096],
+                ), 4090)}```""",
                 fields=embed_fields,
                 footer=f"{interaction.guild.name} ({interaction.guild.id})",
                 footer_icon=interaction.guild.icon.url,
@@ -206,6 +207,11 @@ class ErrorHandling(commands.Cog):
             await channel.send(
                 embed=SersiEmbed(
                     title="An Error Has Occurred",
+                    description=f"""```{limit_string("".join(
+                        traceback.format_exception(
+                            type(error), value=error, tb=error.__traceback__
+                        )
+                    ), 4090)}```""",
                     fields={
                         "Server:": f"{ctx.guild.name} ({ctx.guild.id})",
                         "Channel:": f"{ctx.channel.name} ({ctx.channel.id})",
@@ -213,6 +219,8 @@ class ErrorHandling(commands.Cog):
                         "Error:": error,
                         "URL:": ctx.message.jump_url,
                     },
+                    footer=f"{ctx.author} ({ctx.author.id})",
+                    footer_icon=ctx.author.avatar.url,
                     colour=nextcord.Color.from_rgb(208, 29, 29),
                 )
             )

--- a/cogs/misc/errorhandling.py
+++ b/cogs/misc/errorhandling.py
@@ -213,14 +213,12 @@ class ErrorHandling(commands.Cog):
                         )
                     ), 4090)}```""",
                     fields={
-                        "Server:": f"{ctx.guild.name} ({ctx.guild.id})",
-                        "Channel:": f"{ctx.channel.name} ({ctx.channel.id})",
+                        "Context:": f"{ctx.message.jump_url} (#{ctx.channel.name} `{ctx.channel.id}`)",
+                        "User:": f"{ctx.author.mention} ({ctx.author.display_name} `{ctx.author.id}`)",
                         "Command:": ctx.message.content,
-                        "Error:": error,
-                        "URL:": ctx.message.jump_url,
                     },
-                    footer=f"{ctx.author} ({ctx.author.id})",
-                    footer_icon=ctx.author.avatar.url,
+                    footer=f"{ctx.guild.name} ({ctx.guild.id})",
+                    footer_icon=ctx.guild.icon.url,
                     colour=nextcord.Color.from_rgb(208, 29, 29),
                 )
             )

--- a/cogs/misc/staff_manage.py
+++ b/cogs/misc/staff_manage.py
@@ -12,9 +12,9 @@ from utils.perms import (
     is_slt,
     is_dark_mod,
     is_cet_lead,
-    blacklist_check,
 )
 from utils.database import StaffBlacklist, db_session
+from utils.roles import blacklist_check
 
 
 class Staff(commands.Cog):

--- a/cogs/misc/tickets.py
+++ b/cogs/misc/tickets.py
@@ -290,7 +290,7 @@ class TicketingSystem(commands.Cog):
         ),
     ):
         with db_session(interaction.user) as session:
-            filter_dict = {"active": True}
+            filter_dict = {}
             if ticket_id:
                 filter_dict["id"] = ticket_id
             else:
@@ -483,7 +483,6 @@ class TicketingSystem(commands.Cog):
 
     @close.on_autocomplete("ticket_id")
     @escalate.on_autocomplete("ticket_id")
-    @recategorize.on_autocomplete("ticket_id")
     async def ticket_autocomplete(
         self, interaction: nextcord.Interaction, ticket_id: str
     ):
@@ -504,6 +503,7 @@ class TicketingSystem(commands.Cog):
 
     @info.on_autocomplete("ticket_id")
     @audit.on_autocomplete("ticket_id")
+    @recategorize.on_autocomplete("ticket_id")
     async def ticket_all_autocomplete(
         self, interaction: nextcord.Interaction, ticket_id: str
     ):

--- a/cogs/misc/tickets.py
+++ b/cogs/misc/tickets.py
@@ -463,6 +463,7 @@ class TicketingSystem(commands.Cog):
                 session.query(TicketCategory)
                 .filter(TicketCategory.category.ilike(f"%{category}%"))
                 .group_by(TicketCategory.category)
+                .limit(25)
                 .all()
             )
             return [category.category for category in categories]
@@ -477,6 +478,7 @@ class TicketingSystem(commands.Cog):
                 session.query(TicketCategory)
                 .filter_by(category=category)
                 .filter(TicketCategory.subcategory.ilike(f"%{subcategory}%"))
+                .limit(25)
                 .all()
             )
             return [subcategory.subcategory for subcategory in subcategories]
@@ -497,6 +499,7 @@ class TicketingSystem(commands.Cog):
                     ),
                 )
                 .group_by(Ticket.id)
+                .limit(25)
                 .all()
             )
             return [ticket.id for ticket in tickets]
@@ -517,6 +520,7 @@ class TicketingSystem(commands.Cog):
                     ),
                 )
                 .group_by(Ticket.id)
+                .limit(25)
                 .all()
             )
             return [ticket.id for ticket in tickets]

--- a/cogs/moderation/applications.py
+++ b/cogs/moderation/applications.py
@@ -3,7 +3,6 @@ from nextcord.ext import commands
 from nextcord.ui import Button, View, Modal
 from utils.config import Configuration
 from utils.perms import (
-    blacklist_check,
     is_dark_mod,
     permcheck,
     is_senior_mod,
@@ -13,6 +12,7 @@ from utils.perms import (
 from utils.sersi_embed import SersiEmbed
 from datetime import datetime
 import pytz
+from utils.roles import blacklist_check
 
 
 class ModAppModal(Modal):

--- a/cogs/moderation/ban.py
+++ b/cogs/moderation/ban.py
@@ -143,7 +143,7 @@ class BanSystem(commands.Cog):
         if not await permcheck(interaction, is_mod):
             return
 
-        if not await permcheck(interaction, is_full_mod) and ban_type == "emergency":
+        if ban_type == "emergency" and not await permcheck(interaction, is_full_mod):
             return
 
         if ban_type == "emergency" and timeout:
@@ -193,12 +193,16 @@ class BanSystem(commands.Cog):
         except AttributeError:
             pass
 
-        if check_if_banned(offender.id, interaction.guild):
+        try:
+            await interaction.guild.fetch_ban(offender)
             await interaction.send(
                 f"{self.config.emotes.fail} {offender.mention} is already banned.",
                 ephemeral=True,
             )
             return
+
+        except nextcord.NotFound:
+            pass
 
         if not offence_validity_check(offence):
             await interaction.send(

--- a/cogs/moderation/ban.py
+++ b/cogs/moderation/ban.py
@@ -193,7 +193,7 @@ class BanSystem(commands.Cog):
         except AttributeError:
             pass
 
-        if check_if_banned(offender.id):
+        if check_if_banned(offender.id, interaction.guild):
             await interaction.send(
                 f"{self.config.emotes.fail} {offender.mention} is already banned.",
                 ephemeral=True,

--- a/cogs/moderation/cases.py
+++ b/cogs/moderation/cases.py
@@ -749,6 +749,12 @@ class Cases(commands.Cog):
     ):
         if not await permcheck(interaction, is_senior_mod):
             return
+        
+        if not self.config.bot.dev_mode:
+            await interaction.response.send_message(
+                "This command is WIP and is currently disabled."
+            )
+            return
 
         await interaction.response.defer(ephemeral=False)
 

--- a/cogs/moderation/notes.py
+++ b/cogs/moderation/notes.py
@@ -37,7 +37,7 @@ class NoteModal(nextcord.ui.Modal):
                 Note(
                     author=interaction.user.id,
                     member=self.message.author.id,
-                    content=f"{self.note_remarks.value}\n\n{self.message.jump_url}",
+                    content=f"{self.message.jump_url}\n\n{self.note_remarks.value}",
                 )
             )
 

--- a/cogs/moderation/notes.py
+++ b/cogs/moderation/notes.py
@@ -22,7 +22,7 @@ class NoteModal(nextcord.ui.Modal):
         self.note_remarks = nextcord.ui.TextInput(
             label="Note Remarks",
             min_length=8,
-            max_length=1024,
+            max_length=928,
             required=True,
             placeholder="Please enter your note remarks here.",
             style=nextcord.TextInputStyle.paragraph,

--- a/cogs/moderation/notes.py
+++ b/cogs/moderation/notes.py
@@ -178,7 +178,7 @@ class Notes(commands.Cog):
             entry_form="{entry}",
             field_title="{entries[0].list_entry_header}",
             inline_fields=False,
-            cols=10,
+            cols=5,
             per_col=1,
             init_page=int(page),
             member_id=user_id,

--- a/cogs/moderation/notes.py
+++ b/cogs/moderation/notes.py
@@ -37,7 +37,7 @@ class NoteModal(nextcord.ui.Modal):
                 Note(
                     author=interaction.user.id,
                     member=self.message.author.id,
-                    content=f"{self.message.jump_url}\n\n{self.note_remarks.value}",
+                    content=f"{self.note_remarks.value}\n\n{self.message.jump_url}",
                 )
             )
 

--- a/cogs/moderation/perspective.py
+++ b/cogs/moderation/perspective.py
@@ -214,8 +214,6 @@ class Perspective(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: nextcord.message.Message):
-        return  # disable perspective
-
         if ignored_message(self.config, message):
             return
 
@@ -303,4 +301,5 @@ class Perspective(commands.Cog):
 
 
 def setup(bot: commands.Bot, **kwargs):
-    bot.add_cog(Perspective(bot, kwargs["config"]))
+    if kwargs["config"].bot.dev_mode:
+        bot.add_cog(Perspective(bot, kwargs["config"]))

--- a/cogs/moderation/punish.py
+++ b/cogs/moderation/punish.py
@@ -62,13 +62,16 @@ class Punish(commands.Cog):
     async def punishment_roles(
         self, interaction: nextcord.Interaction, punishment: str
     ):
+        if not is_staff(interaction.user):
+            return
+
         if not punishment:
             await interaction.response.send_autocomplete(self.choices.keys())
             return
 
         punish_roles = [
             role for role in self.choices if role.lower().startswith(punishment.lower())
-        ]
+        ][:25]
         await interaction.response.send_autocomplete(punish_roles)
 
 

--- a/cogs/moderation/reformation.py
+++ b/cogs/moderation/reformation.py
@@ -416,6 +416,8 @@ class Reformation(commands.Cog):
                 case.state = "released"
                 session.commit()
 
+                cell_channel = interaction.guild.get_channel(case.cell_channel)
+
             # logging
             embed = SersiEmbed(
                 title="User Has Been Released from Reformation",
@@ -439,7 +441,6 @@ class Reformation(commands.Cog):
             channel = interaction.guild.get_channel(
                 self.config.channels.teachers_lounge
             )
-            cell_channel = interaction.guild.get_channel(case.cell_channel)
 
             transcript = await make_transcript(cell_channel, interaction.channel, embed)
             if transcript is None:
@@ -522,6 +523,8 @@ class Reformation(commands.Cog):
                         case.state = "failed"
                         session.commit()
 
+                        cell_channel = member.guild.get_channel(case.cell_channel)
+
                     ban_embed = SersiEmbed(
                         title=f"Reformation inmate **{member}** ({member.id}) banned!",
                     )
@@ -541,7 +544,6 @@ class Reformation(commands.Cog):
                     channel = member.guild.get_channel(
                         self.config.channels.teachers_lounge
                     )
-                    cell_channel = member.guild.get_channel(case.cell_channel)
 
                     transcript = await make_transcript(cell_channel, channel, ban_embed)
                     if transcript is None:
@@ -584,6 +586,8 @@ class Reformation(commands.Cog):
                     )
                 )
                 session.commit()
+
+                cell_channel = member.guild.get_channel(case.cell_channel)
             
             channel = self.bot.get_channel(self.config.channels.logging)
             await channel.send(embed=embed)
@@ -596,7 +600,6 @@ class Reformation(commands.Cog):
 
             # transcript
             channel = member.guild.get_channel(self.config.channels.teachers_lounge)
-            cell_channel = member.guild.get_channel(case.cell_channel)
 
             transcript = await make_transcript(cell_channel, channel, embed)
             if transcript is None:
@@ -648,6 +651,8 @@ class Reformation(commands.Cog):
                 "Details": case.details,
             }
 
+            cell_channel = guild.get_channel(case.cell_channel)
+
         # logging
         yes_list = "\n• ".join(yes_voters)
 
@@ -657,7 +662,6 @@ class Reformation(commands.Cog):
             color=nextcord.Color.from_rgb(0, 0, 0),
             fields=embed_fields,
         )
-
 
         channel = self.bot.get_channel(self.config.channels.logging)
         await channel.send(embed=embed)
@@ -670,7 +674,6 @@ class Reformation(commands.Cog):
 
         # transcript
         channel = guild.get_channel(self.config.channels.teachers_lounge)
-        cell_channel = guild.get_channel(case.cell_channel)
 
         transcript = await make_transcript(cell_channel, channel, embed)
         if transcript is None:
@@ -700,6 +703,8 @@ class Reformation(commands.Cog):
                 .filter_by(vote_id=details.vote_id, vote="yes")
                 .all()
             ]
+
+            cell_channel = guild.get_channel(case.cell_channel)
 
         # roles
         try:
@@ -743,7 +748,6 @@ class Reformation(commands.Cog):
 
         # transcript
         channel = guild.get_channel(self.config.channels.teachers_lounge)
-        cell_channel = guild.get_channel(case.cell_channel)
 
         transcript = await make_transcript(cell_channel, channel, log_embed)
         if transcript is None:

--- a/cogs/moderation/reformation.py
+++ b/cogs/moderation/reformation.py
@@ -161,10 +161,12 @@ class Reformation(commands.Cog):
 
             await case_channel.send(embed=welcome_embed)
 
+            message = await interaction.original_message()
+
             embed = SersiEmbed(
                 title="User Has Been Sent to Reformation",
                 description=f"Moderator {interaction.user.mention} ({interaction.user.id}) has sent user {member.mention}"
-                f" ({member.id}) to reformation.\n\n" + f"**__Reason:__**\n{reason}",
+                f" ({member.id}) to reformation.\n\n" + f"**__Reason:__**\n{reason}\n\n[Link to context]({message.jump_url})",
                 color=nextcord.Color.from_rgb(237, 91, 6),
             )
 

--- a/cogs/moderation/reformation.py
+++ b/cogs/moderation/reformation.py
@@ -161,12 +161,24 @@ class Reformation(commands.Cog):
 
             await case_channel.send(embed=welcome_embed)
 
-            message = await interaction.original_message()
+            embed_fields = {
+                "Offence:": offence,
+                "Details:": details,
+            }
+
+            try:
+                message = await interaction.original_message()
+            except nextcord.HTTPException | nextcord.ClientException:
+                message = None
+
+            if message is not None:
+                embed_fields["Context:"] = message.jump_url
 
             embed = SersiEmbed(
                 title="User Has Been Sent to Reformation",
                 description=f"Moderator {interaction.user.mention} ({interaction.user.id}) has sent user {member.mention}"
-                f" ({member.id}) to reformation.\n\n" + f"**__Reason:__**\n{reason}\n\n[Link to context]({message.jump_url})",
+                f" ({member.id}) to reformation.",
+                fields=embed_fields,
                 color=nextcord.Color.from_rgb(237, 91, 6),
             )
 
@@ -185,6 +197,9 @@ class Reformation(commands.Cog):
                 self.config.channels.reform_public_log
             )
             await channel.send(embed=embed)
+
+            if embed_fields.get("Context:") is not None:
+                embed.remove_field(-1)
 
             return embed
 
@@ -424,7 +439,10 @@ class Reformation(commands.Cog):
             embed = SersiEmbed(
                 title="User Has Been Released from Reformation",
                 description=f"Lead Moderator {interaction.user.mention} ({interaction.user.id}) has released user {member.mention}"
-                f" ({member.id}) from reformation.\n\n" + f"**__Reason:__**\n{reason}",
+                f" ({member.id}) from reformation.",
+                fields={
+                    "Reason": reason,
+                },
                 color=nextcord.Color.from_rgb(237, 91, 6),
             )
 
@@ -444,7 +462,7 @@ class Reformation(commands.Cog):
                 self.config.channels.teachers_lounge
             )
 
-            transcript = await make_transcript(cell_channel, interaction.channel, embed)
+            transcript = await make_transcript(cell_channel, channel, embed)
             if transcript is None:
                 await channel.send(embed=embed)
                 await channel.send(f"{self.sersifail} Failed to Generate Transcript!")
@@ -590,7 +608,7 @@ class Reformation(commands.Cog):
                 session.commit()
 
                 cell_channel = member.guild.get_channel(case.cell_channel)
-            
+
             channel = self.bot.get_channel(self.config.channels.logging)
             await channel.send(embed=embed)
 

--- a/cogs/moderation/slur.py
+++ b/cogs/moderation/slur.py
@@ -223,7 +223,7 @@ class ViewNotesButton(nextcord.ui.Button):
             entry_form=format_entry,
             field_title="{entries[0][0]}",
             inline_fields=False,
-            cols=10,
+            cols=5,
             per_col=1,
             init_page=0,
             member_id=str(user.id),

--- a/cogs/moderation/slur_commands.py
+++ b/cogs/moderation/slur_commands.py
@@ -233,7 +233,9 @@ class SlurCommands(nextcord.ext.commands.Cog):
         if not is_mod(interaction.user):
             await interaction.response.send_autocomplete([])
 
-        slurs = [slur for slur in get_slurs() if slur.lower().startswith(input.lower())]
+        slurs = [
+            slur for slur in get_slurs() if slur.lower().startswith(input.lower())
+        ][:25]
         await interaction.response.send_autocomplete(slurs)
 
     @slur_detection.subcommand(
@@ -284,7 +286,7 @@ class SlurCommands(nextcord.ext.commands.Cog):
 
         goodwords = [
             word for word in get_goodwords() if word.lower().startswith(input.lower())
-        ]
+        ][:25]
         await interaction.response.send_autocomplete(goodwords)
 
     @slur_detection.subcommand(description="List currently detected slurs.")

--- a/cogs/moderation/timeout.py
+++ b/cogs/moderation/timeout.py
@@ -134,11 +134,16 @@ class TimeoutSystem(commands.Cog):
         if not await permcheck(interaction, is_mod):
             return
 
-        # if check_if_timeout(offender):
-        #    await interaction.response.send_message(
-        #        f"{self.config.emotes.fail} {offender.mention} is already timed out."
-        #    )
-        #    return
+        if (
+            offender.communication_disabled_until is not None
+            and offender.communication_disabled_until
+            > datetime.datetime.now(offender.communication_disabled_until.tzinfo)
+        ):
+            await interaction.response.send_message(
+                f"{self.config.emotes.fail} {offender.mention} is already timed out.",
+                ephemeral=True,
+            )
+            return
 
         await interaction.response.defer(ephemeral=False)
 

--- a/cogs/moderation/timeout.py
+++ b/cogs/moderation/timeout.py
@@ -134,11 +134,11 @@ class TimeoutSystem(commands.Cog):
         if not await permcheck(interaction, is_mod):
             return
 
-        if check_if_timeout(offender):
-            await interaction.response.send_message(
-                f"{self.config.emotes.fail} {offender.mention} is already timed out."
-            )
-            return
+        # if check_if_timeout(offender):
+        #    await interaction.response.send_message(
+        #        f"{self.config.emotes.fail} {offender.mention} is already timed out."
+        #    )
+        #    return
 
         await interaction.response.defer(ephemeral=False)
 

--- a/cogs/moderation/whois.py
+++ b/cogs/moderation/whois.py
@@ -159,7 +159,7 @@ class WhoisSystem(commands.Cog):
                     entry_form="{entry}",
                     field_title="{entries[0].list_entry_header}",
                     inline_fields=False,
-                    cols=10,
+                    cols=5,
                     per_col=1,
                     init_page=1,
                     ephemeral=True,

--- a/main.py
+++ b/main.py
@@ -111,17 +111,23 @@ async def cog(
 
 @cog.on_autocomplete("category")
 async def cog_category_autocomplete(interaction: nextcord.Interaction, category: str):
+    if not is_sersi_contributor(interaction.user):
+        return
+
     categories = [dir for dir in os.listdir("./cogs") if dir != "__pycache__"]
     if not category:
         return categories
 
-    return [c for c in categories if c.startswith(category)]
+    return [c for c in categories if c.startswith(category)][:25]
 
 
 @cog.on_autocomplete("cog")
 async def cog_cog_autocomplete(
     interaction: nextcord.Interaction, cog_name: str, action: str, category: str
 ):
+    if not is_sersi_contributor(interaction.user):
+        return
+
     bot_cogs = [
         cog_name.removeprefix(f"cogs.{category}.")
         for cog_name in bot.extensions.keys()
@@ -153,7 +159,7 @@ async def cog_cog_autocomplete(
         cog_suggestion
         for cog_suggestion in available_cogs
         if cog_suggestion.startswith(cog_name)
-    ]
+    ][:25]
 
 
 @bot.command()

--- a/persistent_data/config.eu.yaml
+++ b/persistent_data/config.eu.yaml
@@ -24,9 +24,9 @@ bot:
     dev_mode: true
     prefix: "s!"
     status: "Sword and shield"
-    port:   8074 # 8074 for live, 8113 for unstable
+    port:   8113 # 8074 for live, 8113 for unstable
     minimum caps length: 8
-    version: "5.0.0"
+    version: "5.0.1"
     git_url: "https://github.com/Yoshod/Sersi"
     authors:
         - "• Hekkland#0001 `261870562798731266`"

--- a/persistent_data/config.testing.yaml
+++ b/persistent_data/config.testing.yaml
@@ -26,7 +26,7 @@ bot:
     status: "melanie did this"
     port:   8113 # 8074 for live, 8113 for unstable
     minimum caps length: 8
-    version: "5.0.0"
+    version: "5.0.1"
     git_url: "https://github.com/Yoshod/Sersi"
     authors:
         - "• Hekkland#0001 `261870562798731266`"

--- a/persistent_data/config.yaml
+++ b/persistent_data/config.yaml
@@ -26,7 +26,7 @@ bot:
     status: "Sword and shield"
     port:   8074 # 8074 for live, 8113 for unstable
     minimum caps length: 8
-    version: "5.0.0"
+    version: "5.0.1"
     git_url: "https://github.com/Yoshod/Sersi"
     authors:
         - "• Hekkland#0001 `261870562798731266`"

--- a/utils/base.py
+++ b/utils/base.py
@@ -58,7 +58,7 @@ async def ban(
         await member.send(embed=goodbye_embed)
 
     except nextcord.errors.Forbidden:
-        return
+        pass
 
     await member.ban(reason=reason, delete_message_days=0)
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -396,3 +396,10 @@ def convert_to_timedelta(timespan: str, duration: int) -> datetime.timedelta | N
                 return datetime.timedelta(weeks=duration)
 
     return None
+
+
+def limit_string(string: str, length: int = 1024) -> str:
+    if len(string) > length:
+        return string[: length - 3].rstrip(" .,\n") + "..."
+    else:
+        return string

--- a/utils/cases.py
+++ b/utils/cases.py
@@ -27,7 +27,7 @@ def fetch_cases_by_partial_id(case_id: str) -> list[str]:
     with db_session() as session:
         cases: list[typing.Tuple(str)] = (
             session.query(Case.id)
-            .filter(Case.id.like(f"%{case_id}%"))
+            .filter(Case.id.ilike(f"%{case_id}%"))
             .order_by(Case.created.desc())
             .limit(25)
             .all()

--- a/utils/database.py
+++ b/utils/database.py
@@ -374,9 +374,9 @@ class Note(_Base):
             r"https://discord.com/channels/[0-9]*/[0-9]*/[0-9]*", self.content
         ):
             after_link = self.content[link.end() :].lstrip(" \n")
-            return f"<@{self.member}> {link.group(0)}\n```{limit_string(after_link, 128) or 'N/A'}```"
+            return f"<@{self.member}> {link.group(0)}\n```{limit_string(after_link, 224) or 'N/A'}```"
 
-        return f"<@{self.member}>\n```{limit_string(self.content, 128) or 'N/A'}```"
+        return f"<@{self.member}>\n```{limit_string(self.content, 224) or 'N/A'}```"
 
 
 class NoteEdits(_Base):

--- a/utils/database.py
+++ b/utils/database.py
@@ -26,7 +26,7 @@ def random_id() -> str:
     return "".join(random.sample(_alphabet, 11))
 
 
-_engine = sqlalchemy.create_engine("sqlite:///persistent_data/sersi.db", echo=True)
+_engine = sqlalchemy.create_engine("sqlite:///persistent_data/sersi.db")
 _Base = declarative_base()
 
 

--- a/utils/database.py
+++ b/utils/database.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any
 import random
+import re
 
 import nextcord
 import sqlalchemy
@@ -9,6 +10,8 @@ from sqlalchemy.orm import Session, relationship
 from sqlalchemy.ext.declarative import declarative_base
 from shortuuid.main import int_to_string, string_to_int
 
+
+from utils.base import limit_string
 
 # base on https://github.com/skorokithakis/shortuuid
 _alphabet = list("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
@@ -42,13 +45,6 @@ def db_session(owner: int | nextcord.User | nextcord.Member = None):
             session.owner_id = 0
 
     return session
-
-
-def format_notes(note: str):
-    if len(note) >= 135:
-        return f"{note[:127].strip()}..."
-    else:
-        return note
 
 
 ### Case Models ###
@@ -373,7 +369,14 @@ class Note(_Base):
         )
 
     def __repr__(self):
-        return f"<@{self.member}>\n```{format_notes(self.content) or 'N/A'}```"
+        link: re.Match
+        if link := re.match(
+            r"https://discord.com/channels/[0-9]*/[0-9]*/[0-9]*", self.content
+        ):
+            after_link = self.content[link.end() :].lstrip(" \n")
+            return f"<@{self.member}> {link.group(0)}\n```{limit_string(after_link, 128) or 'N/A'}```"
+
+        return f"<@{self.member}>\n```{limit_string(self.content, 128) or 'N/A'}```"
 
 
 class NoteEdits(_Base):

--- a/utils/notes.py
+++ b/utils/notes.py
@@ -51,7 +51,7 @@ def fetch_notes_by_partial_id(note_id: str) -> list[str]:
         return [
             note[0]
             for note in session.query(Note.id)
-            .filter(Note.id.like(f"{note_id}%"))
+            .filter(Note.id.ilike(f"{note_id}%"))
             .limit(25)
             .all()
         ]

--- a/utils/offences.py
+++ b/utils/offences.py
@@ -7,7 +7,7 @@ def fetch_offences_by_partial_name(offence: str) -> list[str]:
     with db_session() as session:
         offences: list[typing.Tuple(str)] = (
             session.query(Offence.offence)
-            .filter(Offence.offence.like(f"%{offence}%"))
+            .filter(Offence.offence.ilike(f"%{offence}%"))
             .order_by(Offence.offence.asc())
             .limit(25)
             .all()

--- a/utils/perms.py
+++ b/utils/perms.py
@@ -1,11 +1,10 @@
 import nextcord
 import nextcord.ext.commands
 
-from utils import config
-from utils.database import StaffBlacklist, db_session
+from utils.config import Configuration
 from utils.sersi_embed import SersiEmbed
 
-config = config.Configuration.from_yaml_file("./persistent_data/config.yaml")
+config = Configuration.from_yaml_file("./persistent_data/config.yaml")
 
 
 async def permcheck(
@@ -229,16 +228,3 @@ async def cb_is_dark_mod(interaction) -> bool:
 
 async def cb_is_cet(interaction) -> bool:
     return await permcheck(interaction, is_cet)
-
-
-def blacklist_check(user: nextcord.Member):
-    with db_session() as session:
-        blacklisted = (
-            session.query(StaffBlacklist).filter_by(blacklisted_user=user.id).first()
-        )
-
-        if blacklisted:
-            return True
-
-        else:
-            return False

--- a/utils/roles.py
+++ b/utils/roles.py
@@ -1,5 +1,7 @@
 import nextcord
 
+from utils.database import db_session, StaffBlacklist
+
 
 def parse_roles(guild: nextcord.Guild, *roles: nextcord.Role | int):
     """Parses roles for use in role assignment/removal on member."""
@@ -11,3 +13,17 @@ def parse_roles(guild: nextcord.Guild, *roles: nextcord.Role | int):
                 role_obj = guild.get_role(role)
                 if role_obj is not None:
                     yield role_obj
+
+
+def blacklist_check(user: nextcord.Member):
+    with db_session() as session:
+        blacklisted = (
+            session.query(StaffBlacklist).filter_by(blacklisted_user=user.id).first()
+        )
+
+        if blacklisted:
+            return True
+
+        else:
+            return False
+


### PR DESCRIPTION
**__Sersi Version 5.0.1__**
- **Notes:**
 - linked message shows up as proper discord message link in list view, no longer displayed raw in preview
 - increased note preview length from 128 to 224 characters
 - reduced number of notes per page from 10 to 5 in list view
 - removed possibility of message notes being too long due to the added link
- **Moderation Votes:**
 - added `/redo_vote_action` command for Sersi contributors to trigger vote action again in case of an error preventing proper execution
- **Reformation:**
 - improved embeds in Teacher Lounge/Reformation Logs
- **Slash Commands:**
 - added limits and perm checks where missing to autocomplete
 - reworked Ministerium error logging embeds for improved legibility and information quality, now show stack tracebacks
- **Fixes:**
 - `/timeout add` now checks if the user is timed out in discord
 - properly disabled some work in progress features if not in development mode